### PR TITLE
Replacing few iterations with only one & Add spinner

### DIFF
--- a/react/src/pages/AntMedia.js
+++ b/react/src/pages/AntMedia.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Grid } from "@mui/material";
+import { Grid, CircularProgress, Box } from "@mui/material";
 import { useParams } from "react-router-dom";
 import _ from "lodash";
 import WaitingRoom from "./WaitingRoom";
@@ -1222,7 +1222,22 @@ function AntMedia() {
     webRTCAdaptor.enableAudioLevelForLocalStream(listener, period);
   }
 
-  return (!initialized ? <>hello</> :
+  return (!initialized ? <> 
+    <Grid
+        container
+        spacing={0}
+        direction="column"
+        alignItems="center"
+        justifyContent="center"
+        style={{ minHeight: '100vh' }}
+      >
+        <Grid item xs={3}>
+        <Box sx={{ display: 'flex' }}>
+          <CircularProgress size="4rem" />
+        </Box>
+        </Grid>   
+      </Grid> 
+    </> :
     <Grid container className="App">
       <Grid
         container

--- a/react/src/pages/MeetingRoom.js
+++ b/react/src/pages/MeetingRoom.js
@@ -307,6 +307,9 @@ const MeetingRoom = React.memo((props) => {
 
   const pinLayout = conference.pinnedVideoId !== null ? true : false;
   // const testPart = [{ name: 'a' }, { name: 'a' }];
+
+  const pinnedVideo = pinLayout && conference.participants.find((v) => v.id === conference.pinnedVideoId)
+
   return (
         <>
           {conference.audioTracks.map((audio, index) => (
@@ -402,24 +405,22 @@ const MeetingRoom = React.memo((props) => {
                       </div>
                   ) : (
                       //pinned participant
-
-                      conference.participants.find((v) => v.id === conference.pinnedVideoId) && (
+                      pinnedVideo && (
                           <div className="single-video-container pinned keep-ratio">
                             <VideoCard
-                                id={conference.participants.find((v) => v.id === conference.pinnedVideoId)?.id}
+                                id={pinnedVideo?.id}
                                 track={
-                                  conference.participants.find((v) => v.id === conference.pinnedVideoId)?.track
+                                  pinnedVideo?.track
                                 }
                                 autoPlay
                                 name={
-                                  conference.participants.find((v) => v.id === conference.pinnedVideoId)?.name
+                                  pinnedVideo?.name
                                 }
                                 pinned
                                 onHandlePin={() => {
                                   conference.pinVideo(
-                                    conference.participants.find((v) => v.id === conference.pinnedVideoId)?.id,
-                                    conference.participants.find((v) => v.id === conference.innedVideoId)
-                                          ?.videoLabel
+                                    pinnedVideo.id,
+                                    pinnedVideo.videoLabel
                                   );
                                 }}
                             />


### PR DESCRIPTION
Avoiding doing five iterations doing only one and putting the result into a constant if the element will be rendered, so if not it won't run into the iteration.

Add a spinner while the browser gets ready 
I.e: For some reason in my firefox sometimes my camera takes like 6-8 secons to be ready and all I can see is the green background, so just added a spinner :) 